### PR TITLE
Add compute shader to raytrace SDF intersections

### DIFF
--- a/Assets/Code/SDFTracer/SDFRaycast.compute
+++ b/Assets/Code/SDFTracer/SDFRaycast.compute
@@ -1,0 +1,47 @@
+#pragma kernel CSMain
+
+StructuredBuffer<float3> _Directions;
+RWStructuredBuffer<float4> _Intersections;
+
+float4x4 _WorldToSDFSpace;
+Texture3D<float> _SDF;
+SamplerState sampler_SDF;
+float _Margin;
+int _MaxIterations;
+float _MaxDistance;
+float _HitThreshold;
+
+float SampleSDF(float3 worldPos)
+{
+    float3 sdfLocalPos = mul(_WorldToSDFSpace, float4(worldPos, 1.0)).xyz;
+    return _SDF.SampleLevel(sampler_SDF, sdfLocalPos, 0).r - _Margin;
+}
+
+[numthreads(64,1,1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+    uint count, stride;
+    _Directions.GetDimensions(count, stride);
+    if (id.x >= count)
+        return;
+
+    float3 dir = normalize(_Directions[id.x]);
+    float t = 0.0;
+    float3 pos = float3(0.0, 0.0, 0.0);
+    bool hit = false;
+
+    for (uint i = 0; i < (uint)_MaxIterations && t < _MaxDistance; ++i)
+    {
+        float dist = SampleSDF(pos);
+        if (dist < _HitThreshold)
+        {
+            hit = true;
+            break;
+        }
+        t += dist;
+        pos = dir * t;
+    }
+
+    _Intersections[id.x] = float4(pos, hit ? 1.0 : 0.0);
+}
+

--- a/Assets/Code/SDFTracer/SDFRaycast.compute.meta
+++ b/Assets/Code/SDFTracer/SDFRaycast.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3c7828105fe4b0d8b5869cfed2d8906
+ComputeShaderImporter:
+  externalObjects: {}
+  preprocessorDefines: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Code/SDFTracer/SDFRaycaster.cs
+++ b/Assets/Code/SDFTracer/SDFRaycaster.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+public class SDFRaycaster : MonoBehaviour
+{
+    public ComputeShader raycastShader;
+    public SDFTexture sdf;
+    public Vector3[] directions;
+    public float maxDistance = 10f;
+    public int maxIterations = 64;
+    public float hitThreshold = 0.001f;
+
+    ComputeBuffer directionsBuffer;
+    ComputeBuffer intersectionsBuffer;
+    Vector4[] intersectionData;
+
+    public Vector4[] Intersections => intersectionData;
+
+    void Start()
+    {
+        if (raycastShader == null || sdf == null || directions == null || directions.Length == 0)
+            return;
+
+        directionsBuffer = new ComputeBuffer(directions.Length, sizeof(float) * 3);
+        directionsBuffer.SetData(directions);
+
+        intersectionsBuffer = new ComputeBuffer(directions.Length, sizeof(float) * 4);
+
+        int kernel = raycastShader.FindKernel("CSMain");
+        raycastShader.SetBuffer(kernel, "_Directions", directionsBuffer);
+        raycastShader.SetBuffer(kernel, "_Intersections", intersectionsBuffer);
+        raycastShader.SetMatrix("_WorldToSDFSpace", sdf.worldToSDFTexCoords);
+        raycastShader.SetTexture(kernel, "_SDF", sdf.sdf);
+        raycastShader.SetFloat("_Margin", 0.0f);
+        raycastShader.SetInt("_MaxIterations", maxIterations);
+        raycastShader.SetFloat("_MaxDistance", maxDistance);
+        raycastShader.SetFloat("_HitThreshold", hitThreshold);
+
+        uint threadGroupSizeX;
+        raycastShader.GetKernelThreadGroupSizes(kernel, out threadGroupSizeX, out _, out _);
+        int groupCount = Mathf.CeilToInt((float)directions.Length / threadGroupSizeX);
+        raycastShader.Dispatch(kernel, groupCount, 1, 1);
+
+        intersectionData = new Vector4[directions.Length];
+        intersectionsBuffer.GetData(intersectionData);
+    }
+
+    void OnDestroy()
+    {
+        directionsBuffer?.Release();
+        intersectionsBuffer?.Release();
+    }
+}

--- a/Assets/Code/SDFTracer/SDFRaycaster.cs.meta
+++ b/Assets/Code/SDFTracer/SDFRaycaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07cb46f62bf9479daa4c06c1354c3271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add compute shader that sphere-traces rays against scene SDF and writes hit positions
- add C# helper to dispatch the compute shader and retrieve intersection data

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689db41168a48325820db796d40fef32